### PR TITLE
[QOLDEV-1075] pin test Solr versions to CKAN version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,15 +28,19 @@ jobs:
         include:
           - ckan-version: "2.11"
             ckan-image: "2.11-py3.10"
+            solr-version: "9"
             experimental: false
           - ckan-version: "2.10"
             ckan-image: "2.10-py3.10"
+            solr-version: "8"
             experimental: false
           - ckan-version: "2.9"
             ckan-image: "2.9-py3.9"
+            solr-version: "8"
             experimental: false
           - ckan-version: "master"
             ckan-image: "master"
+            solr-version: "9"
             experimental: true  # master is unstable, good to know if we are compatible or not
       fail-fast: false
 
@@ -47,7 +51,7 @@ jobs:
       options: --user root
     services:
       solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr${{matrix.solr-version}}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:


### PR DESCRIPTION
- CKAN 2.11+ needs Solr 9, earlier versions need 8